### PR TITLE
 Provide Promise-based hook for when lunr is loaded

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -6,6 +6,16 @@ exports.onClientEntry = (
     args,
     { languages, filename = "search_index.json" }
 ) => {
+    // Setup a promise to be resolved/rejected after Lunr is loaded
+    let resolveLoaded;
+    let rejectLoaded;
+    let loadedPromise = new Promise(function(resolve, reject) {
+        resolveLoaded = resolve;
+        rejectLoaded = reject;
+    });
+    window.__LUNR__ = window.__LUNR__ || {};
+    window.__LUNR__.__loaded = loadedPromise;
+    
     enhanceLunr(lunr, languages);
     fetch(`${__PATH_PREFIX__}/${filename}`)
         .then(function(response) {
@@ -20,8 +30,14 @@ exports.onClientEntry = (
                         store: fullIndex[key].store
                     }
                 }),
-                {}
+                {
+                    __loaded: window.__LUNR__.__loaded
+                }
             );
+            resolveLoaded(window.__LUNR__);
         })
-        .catch(e => console.log("Failed fetch search index"));
+        .catch(e => {
+            rejectLoaded(new Error("Failed fetch search index"));
+            console.log("Failed fetch search index");
+        });
 };

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -6,18 +6,9 @@ exports.onClientEntry = (
     args,
     { languages, filename = "search_index.json" }
 ) => {
-    // Setup a promise to be resolved/rejected after Lunr is loaded
-    let resolveLoaded;
-    let rejectLoaded;
-    let loadedPromise = new Promise(function(resolve, reject) {
-        resolveLoaded = resolve;
-        rejectLoaded = reject;
-    });
-    window.__LUNR__ = window.__LUNR__ || {};
-    window.__LUNR__.__loaded = loadedPromise;
-    
     enhanceLunr(lunr, languages);
-    fetch(`${__PATH_PREFIX__}/${filename}`)
+    window.__LUNR__ = window.__LUNR__ || {};
+    window.__LUNR__.__loaded = fetch(`${__PATH_PREFIX__}/${filename}`)
         .then(function(response) {
             return response.json();
         })
@@ -34,10 +25,10 @@ exports.onClientEntry = (
                     __loaded: window.__LUNR__.__loaded
                 }
             );
-            resolveLoaded(window.__LUNR__);
+            return window.__LUNR__;
         })
         .catch(e => {
-            rejectLoaded(new Error("Failed fetch search index"));
             console.log("Failed fetch search index");
+            throw e;
         });
 };


### PR DESCRIPTION
Fixes #11

Enables code like so on the client, which resolves the issue of first page loads not being able to access `window.__LUNR_`

```javascript
window.__LUNR__.__loaded.then(lunr => {
  // Do lunr search here
});
```