### PR TITLE
require TinySegmenter if 'ja' is specified

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -4,6 +4,9 @@ const enhanceLunr = (lunr, lngs) => {
     lngs.forEach(({name}) => {
       if (name !== 'en') {
         try {
+          if (name === 'jp' || name === 'ja') {
+            require(`lunr-languages/tinyseg`)(lunr)
+          }
           require(`lunr-languages/lunr.${name}`)(lunr)
         } catch (e) {
           console.log(e)


### PR DESCRIPTION
In [`MihaiValentin/lunr-languages`](https://github.com/MihaiValentin/lunr-languages), `lunr.ja.js` depends on `TinySegmenter`. We must `require` it [like this](https://github.com/MihaiValentin/lunr-languages/blob/82c987296b53957036db0b02f0bb8fef24b4b210/test/VersionsAndLanguagesTest.js#L105).