### PR TITLE
Added config option to be passed to fetch call

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ module.exports = {
                 },
                 //custom index file name, default is search_index.json
                 filename: 'search_index.json',
+                //custom options on fetch api call for search_ındex.json
+                fetchOptions: {
+                    credentials: 'same-origin'
+                },
             },
         },
     ],

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -4,11 +4,14 @@ const { enhanceLunr } = require("./common.js");
 
 exports.onClientEntry = (
     args,
-    { languages, filename = "search_index.json" }
+    { languages, filename = "search_index.json", fetchOptions = {} }
 ) => {
     enhanceLunr(lunr, languages);
     window.__LUNR__ = window.__LUNR__ || {};
-    window.__LUNR__.__loaded = fetch(`${__PATH_PREFIX__}/${filename}`)
+    window.__LUNR__.__loaded = fetch(
+        `${__PATH_PREFIX__}/${filename}`,
+        fetchOptions
+    )
         .then(function(response) {
             return response.json();
         })


### PR DESCRIPTION
Due to a bug in of Microsoft Edge browser I need to add `{credentials: 'same-origin'}` option ([details](https://stackoverflow.com/questions/54234035/getting-cors-error-as-per-below-in-microsoft-edge-browser-while-calling-azure-se)) to fetch api call for fetching `search_index.json` file. I think it might be handy to pass options to fetch call, hence I suggest an additional option `fetchOptions`. 