### PR TITLE
Fetch index only on certain pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ module.exports = {
                 fetchOptions: {
                     credentials: 'same-origin'
                 },
+
+                // Set includeOptions if you want granular control over how the
+                // Lunr JSON should be included on the site.
+                // This will ensure that a large Lunr payload won't be
+                // loaded until it is necessary.
+                // Each path in the include or exclude properties will be
+                // transformed into a regular expression for matching.
+                // To use the default behaviour, which is to load it on the very
+                // first page load, leave out or set to an empty object.
+                includeOptions: {
+                    include: [
+                      '^\/search',
+                      '^\/404',
+                    ],
+                    exclude: [
+                      '^\/$',
+                    ]
+                },
             },
         },
     ],

--- a/README.md
+++ b/README.md
@@ -213,3 +213,43 @@ export default class Search extends Component {
 ```
 
 Sample code and example on implementing search within gatsby starter project could be found in the article at: https://medium.com/humanseelabs/gatsby-v2-with-a-multi-language-search-plugin-ffc5e04f73bc
+
+## Loading search index on specific pages
+
+If you need to load the search index on specific pages, you can do so using
+the `includeOptions` setting. With the `include` parameter you can set specific
+page paths to include via regex, or you can exclude paths using the `exclude`
+setting.
+
+If you do this, you'll probably want to poll until `window.__LUNR__` is
+available, to prevent trying to fetch the Lunr index while it hasn't been
+loaded yet. You can do this within your React components by writing a
+function that returns a Promise, and then using it to perform your search.
+
+For example, this waits for up to 2 seconds for Lunr:
+
+```javascript
+const getLunr = (languageCode) => {
+  return new Promise ((resolve, reject) => {
+    const limit = 20;
+    let attempts = 0;
+    const interval = setInterval(() => {
+      if (window.__LUNR__ && typeof window.__LUNR__[languageCode] === 'object') {
+        clearInterval(interval);
+        resolve(window.__LUNR__[languageCode]);
+      }
+      attempts += 1;
+      if (attempts >= limit) {
+        clearInterval(interval);
+        reject();
+      }
+    }, 100);
+  });
+};
+```
+
+You can then call `getLunr(languageCode)` within your code, either in
+a Promise chain or using async/await, and run searches on its index.
+
+Depending on the file size of your index, you might want to change the
+poll limit, or the time spent waiting in each polling iteration.

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -10,8 +10,18 @@ const matchesAny = (path, matches = []) => {
     return matched.length;
 };
 
-const shouldIncludeLunr = (path, { include = [], exclude = [] }) =>
-    matchesAny(path, include) && !matchesAny(path, exclude);
+const shouldIncludeLunr = (path, { include = [], exclude = [] }) => {
+    if (include.length && exclude.length) {
+        return matchesAny(path, include) && !matchesAny(path, exclude);
+    }
+    if (include.length && !exclude.length) {
+        return matchesAny(path, include);
+    }
+    if (!include.length && exclude.length) {
+        return !matchesAny(path, exclude);
+    }
+    return false;
+};
 
 const includeLunr = (filename = "search_index.json", fetchOptions = {}) => {
     window.__LUNR__ = window.__LUNR__ || {};

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -2,9 +2,13 @@
 const lunr = require("lunr");
 const { enhanceLunr } = require("./common.js");
 
-const matchesAny = (path, matches) => matches.filter(f => {
-    return f.match(new RegExp(f));
-});
+const matchesAny = (path, matches = []) => {
+    const matched = matches.filter(matchStr => {
+        const m = path.match(new RegExp(matchStr));
+        return m && m.length;
+    });
+    return matched.length;
+};
 
 const shouldIncludeLunr = (path, { include = [], exclude = [] }) =>
     matchesAny(path, include) && !matchesAny(path, exclude);

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -67,7 +67,7 @@ exports.onPreRouteUpdate = (
 ) => {
     if (
         Object.keys(includeOptions).length &&
-        shouldIncludeLunr(path, includeOptions)
+        shouldIncludeLunr(location.pathname, includeOptions)
     ) {
         includeLunr(filename, fetchOptions);
     }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -70,7 +70,7 @@ exports.onPostBootstrap = ({ getNodes, getNode }, pluginOptions) => {
                                 ...Object.keys(fieldResolvers).reduce(
                                     (prev, key) => ({
                                         ...prev,
-                                        [key]: fieldResolvers[key](n, getNode)
+                                        [key]: fieldResolvers[key](n, getNode, getNodes)
                                     }),
                                     {}
                                 )


### PR DESCRIPTION
Handles the case described in #21.

This is done by defining support for additional config, `includeOptions`, which lets you include and exclude specific paths from loading the Lunr search index. If this property isn't present, or an empty object is used as config, it'll use the existing behaviour of loading on the first page load, using `onClientEntry`.

If `includeOptions` is specified, it expects the keys `include` and/or `exclude`, which contains an array of strings that will be converted to RegExps for matching. These will be used in the `onPreRouteUpdate` hook, using the path we're about to navigate to and matching against the `include` and `exclude` paths.

I'm a little unsure about what to do if someone uses an `includeOptions` like `{ include: [], exclude: [] }`. Right now I've got it set to never load the Lunr search index at all, but it might make more sense to bump it back to `onClientEntry` in this case. Interested in your thoughts about this.

Also, we'll want to add a recommendation for some sort of watcher to wait for the Lunr search index to be loaded on the relevant pages before we try using it, something Promise-based probably. Should we include a sample in the code that can optionally be used?